### PR TITLE
Added data_skip argument to launch files.

### DIFF
--- a/freenect_launch/launch/freenect.launch
+++ b/freenect_launch/launch/freenect.launch
@@ -8,6 +8,7 @@
   <arg name="camera" default="camera" />
   <arg name="rgb_frame_id"   default="$(arg tf_prefix)/$(arg camera)_rgb_optical_frame" />
   <arg name="depth_frame_id" default="$(arg tf_prefix)/$(arg camera)_depth_optical_frame" />
+  <arg name="data_skip" default="0" />
 
   <!-- device_id can have the following formats:
          "B00367707227042B": Use device with given serial number
@@ -82,6 +83,7 @@
       <arg name="rgb_camera_info_url"   value="$(arg rgb_camera_info_url)" />
       <arg name="depth_camera_info_url" value="$(arg depth_camera_info_url)" />
       <arg name="depth_registration"    value="$(arg depth_registration)" />
+      <arg name="data_skip"             value="$(arg data_skip)" />
       <arg name="rgb"                   value="$(arg rgb)" />
       <arg name="ir"                    value="$(arg ir)" />
       <arg name="depth"                 value="$(arg depth)" />

--- a/freenect_launch/launch/includes/device.launch
+++ b/freenect_launch/launch/includes/device.launch
@@ -11,6 +11,7 @@
   <arg name="rgb_camera_info_url" />
   <arg name="depth_camera_info_url" />
   <arg name="depth_registration" />
+  <arg name="data_skip" />
 
   <!-- enable libfreenect debug logging -->
   <arg name="libfreenect_debug" default="false" />
@@ -45,6 +46,7 @@
     <param name="rgb_frame_id"   value="$(arg rgb_frame_id)" />
     <param name="depth_frame_id" value="$(arg depth_frame_id)" />
     <param name="depth_registration" value="$(arg depth_registration)" />
+    <param name="data_skip" value="$(arg data_skip)" />
 
     <param name="debug"                     value="$(arg libfreenect_debug)" />
     <param name="enable_rgb_diagnostics"    value="$(arg enable_rgb_diagnostics)" />


### PR DESCRIPTION
Some time ago, data_skip was added as an option for dynamic reconfigure. It would be nice to be able to also set data_skip via the existing launch files, which is what this patch adds.
