### PR TITLE
Including log4cxx in CMakefile file. 

### DIFF
--- a/freenect_camera/CMakeLists.txt
+++ b/freenect_camera/CMakeLists.txt
@@ -15,6 +15,8 @@ find_package(catkin REQUIRED
 # CMake find_package() module.
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(LIBFREENECT REQUIRED libfreenect)
+pkg_check_modules(LOG4CXX REQUIRED liblog4cxx)
+
 find_library(LIBFREENECT_LIBRARY
   NAMES freenect
   PATHS ${LIBFREENECT_LIBRARY_DIRS}
@@ -29,7 +31,8 @@ find_package(Boost REQUIRED COMPONENTS thread)
 include_directories(include
                     ${catkin_INCLUDE_DIRS}
                     ${Boost_INCLUDE_DIR}
-                    ${LIBFREENECT_INCLUDE_DIRS})
+                    ${LIBFREENECT_INCLUDE_DIRS}
+                    ${LOG4CXX_INCLUDE_DIRS})
 
 # build the node and nodelet
 add_executable(freenect_node src/nodes/freenect_node.cpp)
@@ -42,7 +45,8 @@ add_library(freenect_nodelet src/nodelets/driver.cpp)
 target_link_libraries(freenect_nodelet
                       ${catkin_LIBRARIES}
                       ${LIBFREENECT_LIBRARY}
-                      ${Boost_LIBRARY})
+                      ${Boost_LIBRARY}
+                      ${LOG4CXX_LIBRARIES})
 
 catkin_package(DEPENDS
                libfreenect
@@ -66,4 +70,3 @@ install(TARGETS freenect_nodelet
 # add xml file
 install(FILES freenect_nodelets.xml
         DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
-


### PR DESCRIPTION
Compilation on OS X fails without this.