### PR TITLE
Fix libfreenect includes

### DIFF
--- a/freenect_camera/include/freenect_camera/freenect_device.hpp
+++ b/freenect_camera/include/freenect_camera/freenect_device.hpp
@@ -7,8 +7,8 @@
 #include <boost/date_time/posix_time/ptime.hpp>
 #include <stdexcept>
 
-#include <libfreenect/libfreenect.h>
-#include <libfreenect/libfreenect_registration.h>
+#include <libfreenect.h>
+#include <libfreenect-registration.h>
 #include <freenect_camera/image_buffer.hpp>
 
 namespace freenect_camera {

--- a/freenect_camera/include/freenect_camera/freenect_driver.hpp
+++ b/freenect_camera/include/freenect_camera/freenect_driver.hpp
@@ -1,7 +1,7 @@
 #ifndef FREENECT_DRIVER_K8EEAIBB
 #define FREENECT_DRIVER_K8EEAIBB
 
-#include <libfreenect/libfreenect.h>
+#include <libfreenect.h>
 #include <freenect_camera/freenect_device.hpp>
 
 namespace freenect_camera {

--- a/freenect_camera/include/freenect_camera/image_buffer.hpp
+++ b/freenect_camera/include/freenect_camera/image_buffer.hpp
@@ -6,7 +6,7 @@
 #include <boost/shared_ptr.hpp>
 #include <boost/lexical_cast.hpp>
 
-#include <libfreenect/libfreenect.h>
+#include <libfreenect.h>
 
 namespace freenect_camera {
 


### PR DESCRIPTION
In Ubuntu 14.04 the package `libfreenect-dev`installs the header files directly into `/usr/include` and `libfreenect_registration.h` is written with a minus instead of an underscore. This commit fixes the includes so that the package builds under Ubuntu 14.04.