### PR TITLE
add include path for dynamic reconfigure

### DIFF
--- a/freenect_camera/CMakeLists.txt
+++ b/freenect_camera/CMakeLists.txt
@@ -31,6 +31,7 @@ find_package(Boost REQUIRED COMPONENTS thread)
 include_directories(include
                     ${catkin_INCLUDE_DIRS}
                     ${Boost_INCLUDE_DIR}
+                    ${dynamic_reconfigure_PACKAGE_PATH}/cmake/cfgbuild.cmake
                     ${LIBFREENECT_INCLUDE_DIRS}
                     ${LOG4CXX_INCLUDE_DIRS})
 


### PR DESCRIPTION
Based on this build failure: http://build.ros.org:8080/job/Kbin_uX64__freenect_camera__ubuntu_xenial_amd64__binary/2/console
```
23:25:26 [ 20%] Building CXX object CMakeFiles/freenect_nodelet.dir/src/nodelets/driver.cpp.o
23:25:26 /usr/lib/ccache/x86_64-linux-gnu-g++   -DROSCONSOLE_BACKEND_LOG4CXX -DROS_PACKAGE_NAME=\"freenect_camera\" -Dfreenect_nodelet_EXPORTS -I/tmp/binarydeb/ros-kinetic-freenect-camera-0.4.1/obj-x86_64-linux-gnu/devel/include -I/tmp/binarydeb/ros-kinetic-freenect-camera-0.4.1/include -I/opt/ros/kinetic/include -I/opt/ros/kinetic/include/libfreenect -I/usr/include/libusb-1.0  -g -O2 -fstack-protector-strong -Wformat -Werror=format-security -DNDEBUG -Wdate-time -D_FORTIFY_SOURCE=2  -fPIC   -o CMakeFiles/freenect_nodelet.dir/src/nodelets/driver.cpp.o -c /tmp/binarydeb/ros-kinetic-freenect-camera-0.4.1/src/nodelets/driver.cpp
23:25:29 In file included from /tmp/binarydeb/ros-kinetic-freenect-camera-0.4.1/src/nodelets/driver.cpp:39:0:
23:25:29 /tmp/binarydeb/ros-kinetic-freenect-camera-0.4.1/src/nodelets/driver.h:51:44: fatal error: freenect_camera/FreenectConfig.h: No such file or directory
23:25:29 compilation terminated.
23:25:30 CMakeFiles/freenect_nodelet.dir/build.make:65: recipe for target 'CMakeFiles/freenect_nodelet.dir/src/nodelets/driver.cpp.o' failed
```

I found this tutorial: http://wiki.ros.org/dynamic_reconfigure/Tutorials/SettingUpDynamicReconfigureForANode

Which says this path needs to be added to the include directory. 


I'm not sure why this only fails on Xenial. It's passing on Wily and Jessie. http://repositories.ros.org/status_page/ros_kinetic_default.html?q=free