### PR TITLE
update to use non deprecated pluginlib macro

### DIFF
--- a/freenect_camera/src/nodelets/driver.cpp
+++ b/freenect_camera/src/nodelets/driver.cpp
@@ -857,4 +857,4 @@ void DriverNodelet::watchDog (const ros::TimerEvent& event)
 
 // Register as nodelet
 #include <pluginlib/class_list_macros.h>
-PLUGINLIB_DECLARE_CLASS (freenect_camera, driver, freenect_camera::DriverNodelet, nodelet::Nodelet);
+PLUGINLIB_EXPORT_CLASS(freenect_camera::DriverNodelet, nodelet::Nodelet)


### PR DESCRIPTION
These macros deprecated for now 8 years will be removed in the next ROS release (ROS Melodic)
