### PR TITLE
Update freenect_device.hpp

### DIFF
--- a/freenect_camera/include/freenect_camera/freenect_device.hpp
+++ b/freenect_camera/include/freenect_camera/freenect_device.hpp
@@ -7,8 +7,8 @@
 #include <boost/date_time/posix_time/ptime.hpp>
 #include <stdexcept>
 
-#include <libfreenect/libfreenect.h>
-#include <libfreenect/libfreenect_registration.h>
+#include <libfreenect.h>
+#include <libfreenect_registration.h>
 #include <freenect_camera/image_buffer.hpp>
 
 namespace freenect_camera {


### PR DESCRIPTION
The previous header files address gives compilation errors with catkin_make. Now, it no longer does.