### PR TITLE
Update freenect_driver.hpp

### DIFF
--- a/freenect_camera/include/freenect_camera/freenect_driver.hpp
+++ b/freenect_camera/include/freenect_camera/freenect_driver.hpp
@@ -1,7 +1,7 @@
 #ifndef FREENECT_DRIVER_K8EEAIBB
 #define FREENECT_DRIVER_K8EEAIBB
 
-#include <libfreenect/libfreenect.h>
+#include <libfreenect.h>
 #include <freenect_camera/freenect_device.hpp>
 
 namespace freenect_camera {


### PR DESCRIPTION
The previous address of header file gives errors with catkin_make. Now, it no longer does.