### PR TITLE
Update image_buffer.hpp

### DIFF
--- a/freenect_camera/include/freenect_camera/image_buffer.hpp
+++ b/freenect_camera/include/freenect_camera/image_buffer.hpp
@@ -6,7 +6,7 @@
 #include <boost/shared_ptr.hpp>
 #include <boost/lexical_cast.hpp>
 
-#include <libfreenect/libfreenect.h>
+#include <libfreenect.h>
 
 namespace freenect_camera {
 


### PR DESCRIPTION
The previous address of header files gives errors with catkin_make. Now, it no longer does.